### PR TITLE
Add transfer subscription tests

### DIFF
--- a/contracts/SimpleTransfer.sol
+++ b/contracts/SimpleTransfer.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+contract SimpleTransfer {
+    event TransferInitiated(address indexed txOrigin, address indexed sender, uint256 amount);
+
+    function transfer(address payable recipient, uint256 amount) external payable {
+        require(msg.value == amount, "Incorrect amount sent");
+
+        emit TransferInitiated(tx.origin, msg.sender, amount);
+        recipient.transfer(amount);
+    }
+}

--- a/src/account-faucet.ts
+++ b/src/account-faucet.ts
@@ -64,8 +64,14 @@ const parseAmount = (amount?: number | string | bigint | undefined) => {
  * @param account
  * @param amounts
  */
-export const fundAccount = async (account: string, amounts: FundingAmounts) => {
-    const wallet = new ThorWallet(Buffer.from(randomFunder(), 'hex'))
+export const fundAccount = async (
+    account: string,
+    amounts: FundingAmounts,
+    wallet?: ThorWallet,
+) => {
+    if (!wallet) {
+        wallet = new ThorWallet(Buffer.from(randomFunder(), 'hex'))
+    }
 
     const clauses = []
     const vetAmount = parseAmount(amounts.vet)

--- a/src/thor-client.ts
+++ b/src/thor-client.ts
@@ -300,6 +300,7 @@ class ThorClient {
             txOrigin?: string
         },
         callback: (data: Schema['SubscriptionTransferResponse']) => void,
+        errorCallback?: (data: any) => void,
     ) {
         const url = new URL(`${this.baseWsUrl}/subscriptions/transfer`)
 
@@ -319,7 +320,7 @@ class ThorClient {
             url.searchParams.append('txOrigin', queryParameters.txOrigin)
         }
 
-        return this.openWebsocket(url.toString(), callback)
+        return this.openWebsocket(url.toString(), callback, errorCallback)
     }
 
     // WS /subscriptions/beats
@@ -469,11 +470,28 @@ class ThorClient {
         }
     }
 
-    private openWebsocket<T>(url: string, callback: (data: T) => void) {
+    private openWebsocket<T>(
+        url: string,
+        callback: (data: T) => void,
+        errorCallback?: (data: T) => void,
+    ) {
         const ws = new WebSocket(url)
         ws.onmessage = (event: any) => {
             const data = JSON.parse(event.data)
             callback(data)
+        }
+
+        ws.onerror = (event: any) => {
+            if (errorCallback) {
+                errorCallback(event)
+            }
+            const error = new Error(`WebSocket error: ${event.message}`)
+            console.error(error)
+        }
+
+        ws.onclose = (event: any) => {
+            const error = new Error(`WebSocket onclone: ${event.message}`)
+            console.error(error)
         }
 
         this.subscriptions.push(() => ws.close())

--- a/test/thorest-api/subscriptions/ws-transfers.test.ts
+++ b/test/thorest-api/subscriptions/ws-transfers.test.ts
@@ -1,41 +1,241 @@
 import { Client } from '../../../src/thor-client'
 import { components } from '../../../src/open-api-types'
-import { fundingAmounts, fundAccount } from '../../../src/account-faucet'
-import { generateAddress } from '../../../src/wallet'
+import {
+    fundingAmounts,
+    fundAccount,
+    randomFunder,
+} from '../../../src/account-faucet'
+import { SimpleTransfer__factory as SimpleTransfer } from '../../../typechain-types'
+import { generateAddress, ThorWallet } from '../../../src/wallet'
+
+type SubscriptionParams = Record<string, string | undefined>
+
+const subscribeAndTestError = async (
+    params: SubscriptionParams,
+    expectedErrorMessage: string,
+) => {
+    Client.raw.subscribeToTransfers(
+        params,
+        () => {
+            fail(
+                `Callback should not be executed for an invalid parameter: ${JSON.stringify(params)}`,
+            )
+        },
+        (error: { message: string }) => {
+            expect(error.message).toBe(expectedErrorMessage)
+        },
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+}
+
+const subscribeAndFundAccount = async (
+    params: SubscriptionParams,
+    account: string,
+    wallet?: ThorWallet,
+) => {
+    const events: components['schemas']['SubscriptionTransferResponse'][] = []
+
+    Client.raw.subscribeToTransfers(params, (event) => {
+        events.push(event)
+    })
+
+    const { receipt } = wallet
+        ? await fundAccount(account, fundingAmounts.tinyVetNoVtho, wallet)
+        : await fundAccount(account, fundingAmounts.tinyVetNoVtho)
+
+    const sender = receipt.outputs?.[0].transfers?.[0].sender
+
+    // Sleep for 1 sec to ensure the beat is received
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    const relevantEvent = events.find((event) => {
+        return event.meta?.txID === receipt.meta?.txID
+    })
+
+    return { relevantEvent, sender, account }
+}
 
 /**
  * @group api
  * @group websockets
+ * @group transfer
  */
 describe('WS /subscriptions/transfer', () => {
-    it.e2eTest('should be able to subscribe', 'all', async () => {
-        const events: components['schemas']['SubscriptionTransferResponse'][] =
-            []
+    it.e2eTest('should work for valid recipient', 'all', async () => {
         const account = generateAddress()
 
-        Client.raw.subscribeToTransfers(
-            {
-                recipient: account,
-            },
-            (event) => {
-                events.push(event)
-            },
-        )
-
-        const { receipt } = await fundAccount(
+        const { relevantEvent, sender } = await subscribeAndFundAccount(
+            { recipient: account },
             account,
-            fundingAmounts.tinyVetNoVtho,
         )
-        const sender = receipt.outputs?.[0].transfers?.[0].sender
-
-        //sleep for 1 sec to ensure the beat is received
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-
-        const relevantEvent = events.find((event) => {
-            return event.meta?.txID === receipt.meta?.txID
-        })
 
         expect(relevantEvent).not.toBeUndefined()
         expect(relevantEvent?.meta?.txOrigin).toEqual(sender)
+        expect(relevantEvent?.recipient).toEqual(account)
+    })
+
+    it.e2eTest('should work for valid position', 'all', async () => {
+        const account = generateAddress()
+        const bestBlock = await Client.sdk.blocks.getBlockCompressed('best')
+        const bestBlockId = bestBlock?.id
+
+        const { relevantEvent, sender } = await subscribeAndFundAccount(
+            { recipient: account, pos: bestBlockId },
+            account,
+        )
+
+        expect(relevantEvent).not.toBeUndefined()
+        expect(relevantEvent?.meta?.txOrigin).toEqual(sender)
+        expect(relevantEvent?.recipient).toEqual(account)
+    })
+
+    it.e2eTest('should work for valid sender', 'all', async () => {
+        const account = generateAddress()
+        const randomSender = randomFunder()
+        const wallet = new ThorWallet(Buffer.from(randomSender, 'hex'))
+
+        const { relevantEvent, sender } = await subscribeAndFundAccount(
+            { sender: wallet.address },
+            account,
+            wallet,
+        )
+
+        expect(relevantEvent).not.toBeUndefined()
+        expect(relevantEvent?.meta?.txOrigin).toEqual(sender)
+        expect(relevantEvent?.recipient).toEqual(account)
+    })
+
+    it.e2eTest('should work for valid txOrigin', 'all', async () => {
+        const account = generateAddress()
+        const randomSender = randomFunder()
+        const wallet = new ThorWallet(Buffer.from(randomSender, 'hex'))
+
+        const { relevantEvent, sender } = await subscribeAndFundAccount(
+            { txOrigin: wallet.address },
+            account,
+            wallet,
+        )
+
+        expect(relevantEvent).not.toBeUndefined()
+        expect(relevantEvent?.meta?.txOrigin).toEqual(sender)
+        expect(relevantEvent?.recipient).toEqual(account)
+    })
+
+    it.e2eTest(
+        'should work for valid txOrigin different than sender',
+        'all',
+        async () => {
+            const wallet: ThorWallet = ThorWallet.withFunds()
+            const simpleTransfer = await wallet.deployContract(
+                SimpleTransfer.bytecode,
+                SimpleTransfer.abi,
+            )
+            const sender = simpleTransfer.address // contract that sends VET
+            const txOrigin = wallet.address // EOA that triggered contract call
+            const account = generateAddress()
+
+            const functionData =
+                SimpleTransfer.createInterface().encodeFunctionData(
+                    'transfer',
+                    [account, 1],
+                )
+
+            const events: components['schemas']['SubscriptionTransferResponse'][] =
+                []
+
+            Client.raw.subscribeToTransfers({ sender: sender }, (event) => {
+                events.push(event)
+            })
+
+            const receipt = await wallet.sendClauses(
+                [
+                    {
+                        to: sender,
+                        value: '0x1',
+                        data: functionData,
+                    },
+                ],
+                true,
+            )
+
+            expect(receipt).toBeDefined()
+            expect(receipt!.reverted).toBe(false)
+
+            // Sleep for 1 sec to ensure the beat is received
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+
+            const relevantEvent = events.find((event) => {
+                return event.meta?.txID === receipt.meta?.txID
+            })
+
+            expect(relevantEvent).not.toBeUndefined()
+            expect(relevantEvent?.meta?.txOrigin).not.toEqual(sender)
+            expect(relevantEvent?.meta?.txOrigin).toEqual(txOrigin)
+        },
+    )
+
+    it.e2eTest('should get 2 notifications', 'all', async () => {
+        const transferTxs: { id: string }[] = []
+        const txpoolTxs: { id: string }[] = []
+
+        const account = generateAddress()
+
+        Client.raw.subscribeToTransfers({ recipient: account }, (event) => {
+            const txID = event.meta?.txID
+            if (txID) {
+                transferTxs.push({ id: txID })
+            }
+        })
+
+        Client.raw.subscribeToTxPool((txId) => {
+            txpoolTxs.push(txId)
+        })
+
+        // Sleep for 1 sec to ensure the beat is received
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+
+        expect(transferTxs).not.toBeUndefined()
+        expect(txpoolTxs).not.toBeUndefined()
+        expect(transferTxs).toEqual(txpoolTxs)
+    })
+
+    it.e2eTest('should error for invalid position', 'all', async () => {
+        await subscribeAndTestError(
+            { pos: 'invalid position' },
+            'Unexpected server response: 400',
+        )
+    })
+
+    it.e2eTest('should error for out of range position', 'all', async () => {
+        const account = generateAddress()
+        const genesisBlock = await Client.sdk.blocks.getGenesisBlock()
+        const genesisBlockId = genesisBlock?.id
+
+        await subscribeAndTestError(
+            { recipient: account, pos: genesisBlockId },
+            'Unexpected server response: 403',
+        )
+    })
+
+    it.e2eTest('should error for invalid recipient', 'all', async () => {
+        await subscribeAndTestError(
+            { recipient: 'invalid recipient' },
+            'Unexpected server response: 400',
+        )
+    })
+
+    it.e2eTest('should error for invalid txOrigin', 'all', async () => {
+        await subscribeAndTestError(
+            { txOrigin: 'invalid txOrigin' },
+            'Unexpected server response: 400',
+        )
+    })
+
+    it.e2eTest('should error for invalid sender', 'all', async () => {
+        await subscribeAndTestError(
+            { sender: 'invalid sender' },
+            'Unexpected server response: 400',
+        )
     })
 })


### PR DESCRIPTION
PR addresses [this](https://github.com/orgs/vechain/projects/22/views/1?filterQuery=e2e&pane=issue&itemId=72240898) issue. For the negative path I added an optional `errorCallBack` to the `thorClient`. Also to test for a valid sender I added the option to inject the wallet to the `fundAccount` function but let me know if you have better ideas on how to do this. 