### PR TITLE
Fix prestate trace test

### DIFF
--- a/src/thor-client.ts
+++ b/src/thor-client.ts
@@ -369,7 +369,7 @@ class ThorClient {
     }
 
     // POST /debug/tracers/call
-    public async traceContractCall(
+    public async traceCall(
         request: Schema['PostDebugTracerCallRequest'],
         revision?: string,
         options?: AxiosRequestConfig,

--- a/test/evm/individual-opcodes.test.ts
+++ b/test/evm/individual-opcodes.test.ts
@@ -54,7 +54,7 @@ describe('Individual OpCodes', () => {
             data,
         }
 
-        const debugged = await Client.raw.traceContractCall({
+        const debugged = await Client.raw.traceCall({
             ...clause,
             caller,
             gas: 1_000_000,

--- a/test/thorest-api/debug/tracers.test.ts
+++ b/test/thorest-api/debug/tracers.test.ts
@@ -198,7 +198,7 @@ describe('POST /debug/tracers', () => {
     })
 
     it.e2eTest('should return 403 for empty body', 'all', async () => {
-        const response = await Client.raw.traceContractCall({})
+        const response = await Client.raw.traceCall({})
         expect(response.httpCode).toBe(403)
     })
 
@@ -208,7 +208,7 @@ describe('POST /debug/tracers', () => {
     })
 
     it.e2eTest('should return 403 for empty body', 'all', async () => {
-        const response = await Client.raw.traceContractCall('' as any)
+        const response = await Client.raw.traceCall('' as any)
         expect(response.httpCode).toBe(400)
     })
 


### PR DESCRIPTION
Changed the prestate tracer call to do a value transfer instead for calling the energy contract.
The main reason is that the state of `0x7567D83b7b8d80ADdCb281A71d54Fc7B3364ffed` account is slightly different between thor solo and other networks. 

We might consider using the prestate tracer on an existing on-chain transaction so that we can evaluate the pre vs post state changes. It does seem that when using in a call, the prestate tracer behaves as an account state dump.

Also updated the the TraceContractCall to TraceCall and made a similar update to the docs in thor.