### PR TITLE
Remove backtrace test

### DIFF
--- a/network/config/start.sh
+++ b/network/config/start.sh
@@ -15,7 +15,6 @@ thor \
   --config-dir=/tmp \
   --network /node/config/genesis.json \
   --api-addr="0.0.0.0:8669" \
-  --api-backtrace-limit=5 \
   --api-cors="*" \
   --api-allowed-tracers="all" \
   --verbosity=9 \

--- a/network/docker-compose-solo.yaml
+++ b/network/docker-compose-solo.yaml
@@ -9,7 +9,6 @@ services:
             - --genesis=/node/config/genesis.json
             - --on-demand # create new block when there is pending transaction
             - --api-addr=0.0.0.0:8669 # Enable remote connections
-            - --api-backtrace-limit=5 # limit the number of blocks to trace back
             - --api-cors=* # comma separated list of domains to accept cross-origin requests to API
             - --txpool-limit-per-account=256 # limit txpool size per account
             - --cache=1024 # megabytes of ram allocated to trie nodes cache

--- a/test/thorest-api/subscriptions/ws-transfers.test.js
+++ b/test/thorest-api/subscriptions/ws-transfers.test.js
@@ -202,17 +202,6 @@ describe('WS /subscriptions/transfer', () => {
         )
     })
 
-    it.e2eTest('should error for out of range position', 'all', async () => {
-        const account = generateAddress()
-        const genesisBlock = await Client.sdk.blocks.getGenesisBlock()
-        const genesisBlockId = genesisBlock?.id
-
-        await subscribeAndTestError(
-            { recipient: account, pos: genesisBlockId },
-            'Unexpected server response: 403',
-        )
-    })
-
     it.e2eTest('should error for invalid recipient', 'all', async () => {
         await subscribeAndTestError(
             { recipient: 'invalid recipient' },


### PR DESCRIPTION
Sister PR [here](https://github.com/vechain/thor/pull/842)

This PR removes the backtrace limit tests applied via the e2e tests, this feature is now tested in the thor repo.
This allows the e2e tests run with default flags.