### PR TITLE
fix(network): using too much resources

### DIFF
--- a/network/docker-compose-base.yaml
+++ b/network/docker-compose-base.yaml
@@ -11,8 +11,3 @@ services:
             interval: 1s
             timeout: 5s
             retries: 120
-        deploy:
-            resources:
-                limits:
-                    cpus: '4'
-                    memory: 8192M

--- a/network/docker-compose.yaml
+++ b/network/docker-compose.yaml
@@ -3,11 +3,6 @@ services:
         image: ${THOR_IMAGE:-ghcr.io/vechain/thor:master-latest}
         container_name: thor-disco
         entrypoint: 'disco --keyhex=99f0500549792796c14fed62011a51081dc5b5e68fe8bd8a13b86be829c4fd36'
-        deploy:
-            resources:
-                limits:
-                    cpus: '2'
-                    memory: 2048M
 
     authority-node-1:
         extends:


### PR DESCRIPTION
The resources are too high. This prevents us from running the tests in private pipelines