### PR TITLE
feat: `fees/priority` endpoint

### DIFF
--- a/src/dyn-fee-transaction/Transaction.js
+++ b/src/dyn-fee-transaction/Transaction.js
@@ -1,14 +1,18 @@
 import * as nc_utils from '@noble/curves/abstract/utils'
 import {
-    Address, Blake2b256, BufferKind,
+    Address,
+    Blake2b256,
+    BufferKind,
     CompactFixedHexBlobKind,
     Hex,
     HexBlobKind,
     HexUInt,
     NumericKind,
     OptionalFixedHexBlobKind,
-    RLPProfiler, Secp256k1, Units,
-    VTHO
+    RLPProfiler,
+    Secp256k1,
+    Units,
+    VTHO,
 } from '@vechain/sdk-core'
 import {
     InvalidDataType,
@@ -27,7 +31,6 @@ import {
  * Represents an immutable transaction entity.
  */
 class DynFeeTransaction {
-
     static DYNAMIC_FEE_TYPE = 0x51
     /**
      * A collection of constants used for gas calculations in transactions.

--- a/src/dyn-fee-transaction/Transaction.js
+++ b/src/dyn-fee-transaction/Transaction.js
@@ -1,38 +1,34 @@
 import * as nc_utils from '@noble/curves/abstract/utils'
 import {
-    InvalidDataType,
-    InvalidSecp256k1PrivateKey,
-    InvalidTransactionField,
-    NotDelegatedTransaction,
-    UnavailableTransactionField,
-} from '@vechain/sdk-errors'
-import { Secp256k1 } from '@vechain/sdk-core'
-import {
-    Address,
-    BufferKind,
+    Address, Blake2b256, BufferKind,
     CompactFixedHexBlobKind,
     Hex,
     HexBlobKind,
     HexUInt,
     NumericKind,
     OptionalFixedHexBlobKind,
-    RLPProfiler,
-    Units,
-    VTHO,
+    RLPProfiler, Secp256k1, Units,
+    VTHO
 } from '@vechain/sdk-core'
-import { Blake2b256 } from '@vechain/sdk-core'
+import {
+    InvalidDataType,
+    InvalidSecp256k1PrivateKey,
+    InvalidTransactionField,
+    NotDelegatedTransaction,
+    UnavailableTransactionField,
+} from '@vechain/sdk-errors'
 
 /**
  * @typedef {import('./TransactionBody').DynFeeTransactionBody}
  * @typedef {import('@vechain/sdk-core').TransactionClause}
  */
 
-const DynamicFeeTxType = 0x51
-
 /**
  * Represents an immutable transaction entity.
  */
 class DynFeeTransaction {
+
+    static DYNAMIC_FEE_TYPE = 0x51
     /**
      * A collection of constants used for gas calculations in transactions.
      */
@@ -657,7 +653,7 @@ class DynFeeTransaction {
         // Prepend DynamicFeeTxType if the transaction is signed
         if (isSigned) {
             return nc_utils.concatBytes(
-                new Uint8Array([DynamicFeeTxType]),
+                new Uint8Array([DYNAMIC_FEE_TYPE]),
                 encodedBody,
             )
         }

--- a/src/dyn-fee-transaction/Transaction.js
+++ b/src/dyn-fee-transaction/Transaction.js
@@ -31,7 +31,6 @@ import {
  * Represents an immutable transaction entity.
  */
 class DynFeeTransaction {
-    static DYNAMIC_FEE_TYPE = 0x51
     /**
      * A collection of constants used for gas calculations in transactions.
      */
@@ -653,10 +652,11 @@ class DynFeeTransaction {
             isSigned,
         )
 
-        // Prepend DynamicFeeTxType if the transaction is signed
+        // Prepend dynamicFeeTxType if the transaction is signed
+        const dynamicFeeTxType = 0x51
         if (isSigned) {
             return nc_utils.concatBytes(
-                new Uint8Array([DYNAMIC_FEE_TYPE]),
+                new Uint8Array([dynamicFeeTxType]),
                 encodedBody,
             )
         }

--- a/src/thor-client.js
+++ b/src/thor-client.js
@@ -171,6 +171,16 @@ class ThorClient {
         )
     }
 
+    // GET /fees/priority
+    async getFeesPriority(options) {
+        return this.performRequest(() =>
+            this.axios.get(
+                '/fees/priority',
+                options,
+            ),
+        )
+    }
+
     // WS /subscriptions/block
     subscribeToBlocks(callback, pos) {
         let url = `${this.baseWsUrl}/subscriptions/block`

--- a/src/thor-client.js
+++ b/src/thor-client.js
@@ -174,10 +174,7 @@ class ThorClient {
     // GET /fees/priority
     async getFeesPriority(options) {
         return this.performRequest(() =>
-            this.axios.get(
-                '/fees/priority',
-                options,
-            ),
+            this.axios.get('/fees/priority', options),
         )
     }
 

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -151,7 +151,7 @@ class ThorWallet {
                 maxPriorityFeePerGas: options.maxPriorityFeePerGas ?? 10,
                 maxFeePerGas: options.maxFeePerGas ?? 10_000_000_000_000,
                 gas: 1_000_000,
-                dependsOn: options?.dependsOn ?? null,
+                dependsOn: options.dependsOn ?? null,
                 nonce: generateNonce(),
                 chainTag: parseInt(genesisBlock.body.id.slice(-2), 16),
             })
@@ -163,7 +163,7 @@ class ThorWallet {
             clauses: clauses,
             gasPriceCoef: 0,
             gas: 1_000_000,
-            dependsOn: options?.dependsOn ?? null,
+            dependsOn: options.dependsOn ?? null,
             nonce: generateNonce(),
             chainTag: parseInt(genesisBlock.body.id.slice(-2), 16),
         }

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -135,7 +135,7 @@ class ThorWallet {
         return contract
     }
 
-    buildTransaction = async (clauses, options) => {
+    buildTransaction = async (clauses, options = {}) => {
         const bestBlockRef = await getBlockRef('best')
         const genesisBlock = await Client.raw.getBlock('0')
 

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -143,6 +143,20 @@ class ThorWallet {
             throw new Error('Could not get best block')
         }
 
+        if (options.isDynFeeTx) {
+            return new DynFeeTransaction({
+                blockRef: bestBlockRef,
+                expiration: 1000,
+                clauses: clauses,
+                maxPriorityFeePerGas: options.maxPriorityFeePerGas ?? 10,
+                maxFeePerGas: options.maxFeePerGas ?? 10_000_000_000_000,
+                gas: 1_000_000,
+                dependsOn: options?.dependsOn ?? null,
+                nonce: generateNonce(),
+                chainTag: parseInt(genesisBlock.body.id.slice(-2), 16),
+            })
+        }
+
         return {
             blockRef: bestBlockRef,
             expiration: 1000,

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -92,9 +92,8 @@ describe(
                 // This loop will create 8 transactions, 1 included in each block
 
                 // Since we sort the fees and get the position related to the 60th percentile
-
-                // We need to create at least 8 blocks to have a priority fee that is not the expected
-                // assuming that in other tests there are no higher fees than this one
+                // we need to have at least 8 blocks to ensure a priority fee that is the expected
+                // assuming that in other tests there are no higher priority fees than this one
                 for (let i = 0; i < 8; i++) {
                     await sendTransactionsWithTip(
                         wallet,

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -12,7 +12,6 @@ import {
 } from '../transactions/setup/asserts'
 import { TransactionDataDrivenFlow } from '../transactions/setup/transaction-data-driven-flow'
 
-
 const timeout = 100000
 
 const sendTransactionsWithTip = async (wallet, tip, vetAmountInWei) => {
@@ -38,12 +37,10 @@ const sendTransactionsWithTip = async (wallet, tip, vetAmountInWei) => {
             expectedResult: successfulPostTx,
         },
         getTxStep: {
-            expectedResult: (tx) =>
-                compareSentTxWithCreatedTx(tx, signedTx),
+            expectedResult: (tx) => compareSentTxWithCreatedTx(tx, signedTx),
         },
         getTxReceiptStep: {
-            expectedResult: (receipt) =>
-                successfulReceipt(receipt, signedTx),
+            expectedResult: (receipt) => successfulReceipt(receipt, signedTx),
         },
         getLogTransferStep: {
             expectedResult: (input, block) =>
@@ -68,37 +65,50 @@ const sendTransactionsWithTip = async (wallet, tip, vetAmountInWei) => {
  * @group api
  * @group fees
  */
-describe('GET /fees/priority', function () {
-    it.e2eTest('get suggested priority fee', 'all', async () => {
-        const res = await Client.raw.getFeesPriority()
-
-        expect(res.success, 'API response should be a success').toBeTruthy()
-        expect(res.httpCode, 'Expected HTTP Code').toEqual(200)
-        const expectedRes = {
-            maxPriorityFeePerGas: expect.stringMatching(HEX_AT_LEAST_1),
-        }
-        expect(res.body, 'Expected Response Body').toEqual(expectedRes)
-    })
-
-    it.e2eTest(
-        'should suggest a priority fee that is not the minimum',
-        ['solo', 'default-private'],
-        async () => {
-            const wallet = ThorWallet.withFunds()
-
-            const expectedMaxPriorityFee = 80
-            for (let i = 0; i < 8; i++) {
-                await sendTransactionsWithTip(wallet, expectedMaxPriorityFee, i)
-            }
-
+describe(
+    'GET /fees/priority',
+    function () {
+        it.e2eTest('get suggested priority fee', 'all', async () => {
             const res = await Client.raw.getFeesPriority()
 
             expect(res.success, 'API response should be a success').toBeTruthy()
             expect(res.httpCode, 'Expected HTTP Code').toEqual(200)
             const expectedRes = {
-                maxPriorityFeePerGas: HexUInt.of(expectedMaxPriorityFee).toString(),
+                maxPriorityFeePerGas: expect.stringMatching(HEX_AT_LEAST_1),
             }
             expect(res.body, 'Expected Response Body').toEqual(expectedRes)
-        },
-    )
-}, timeout)
+        })
+
+        it.e2eTest(
+            'should suggest a priority fee that is not the minimum',
+            ['solo', 'default-private'],
+            async () => {
+                const wallet = ThorWallet.withFunds()
+
+                const expectedMaxPriorityFee = 80
+                for (let i = 0; i < 8; i++) {
+                    await sendTransactionsWithTip(
+                        wallet,
+                        expectedMaxPriorityFee,
+                        i,
+                    )
+                }
+
+                const res = await Client.raw.getFeesPriority()
+
+                expect(
+                    res.success,
+                    'API response should be a success',
+                ).toBeTruthy()
+                expect(res.httpCode, 'Expected HTTP Code').toEqual(200)
+                const expectedRes = {
+                    maxPriorityFeePerGas: HexUInt.of(
+                        expectedMaxPriorityFee,
+                    ).toString(),
+                }
+                expect(res.body, 'Expected Response Body').toEqual(expectedRes)
+            },
+        )
+    },
+    timeout,
+)

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -7,7 +7,6 @@ import { HEX_AT_LEAST_1 } from '../../../src/utils/hex-utils'
  * @group fees
  */
 describe('GET /fees/priority', function () {
-
     it.e2eTest('get suggested priority fee', 'all', async () => {
         const res = await Client.raw.getFeesPriority()
 

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -1,6 +1,68 @@
+import { Clause, Hex, HexUInt, Units, VET } from '@vechain/sdk-core'
 import { expect } from 'vitest'
 import { Client } from '../../../src/thor-client'
 import { HEX_AT_LEAST_1 } from '../../../src/utils/hex-utils'
+import { ThorWallet } from '../../../src/wallet'
+import {
+    checkTransactionLogSuccess,
+    checkTxInclusionInBlock,
+    compareSentTxWithCreatedTx,
+    successfulPostTx,
+    successfulReceipt,
+} from '../transactions/setup/asserts'
+import { TransactionDataDrivenFlow } from '../transactions/setup/transaction-data-driven-flow'
+
+
+const timeout = 100000
+
+const sendTransactionsWithTip = async (wallet, tip, vetAmountInWei) => {
+    const clause = Clause.transferVET(
+        wallet.address,
+        VET.of(vetAmountInWei, Units.wei),
+    )
+
+    const bestBlk = await Client.raw.getBlock('best')
+    expect(bestBlk.success).toBeTruthy()
+
+    const baseFee = bestBlk.body?.baseFee
+    const txBody = await wallet.buildTransaction([clause], {
+        isDynFeeTx: true,
+        maxFeePerGas: baseFee,
+        maxPriorityFeePerGas: tip,
+    })
+    const signedTx = await wallet.signTransaction(txBody)
+
+    const testPlan = {
+        postTxStep: {
+            rawTx: Hex.of(signedTx.encoded).toString(),
+            expectedResult: successfulPostTx,
+        },
+        getTxStep: {
+            expectedResult: (tx) =>
+                compareSentTxWithCreatedTx(tx, signedTx),
+        },
+        getTxReceiptStep: {
+            expectedResult: (receipt) =>
+                successfulReceipt(receipt, signedTx),
+        },
+        getLogTransferStep: {
+            expectedResult: (input, block) =>
+                checkTransactionLogSuccess(
+                    input,
+                    block,
+                    signedTx,
+                    signedTx.body.clauses,
+                ),
+        },
+        getTxBlockStep: {
+            expectedResult: checkTxInclusionInBlock,
+        },
+    }
+
+    const ddt = new TransactionDataDrivenFlow(testPlan)
+
+    await ddt.runTestFlow()
+}
 
 /**
  * @group api
@@ -17,4 +79,26 @@ describe('GET /fees/priority', function () {
         }
         expect(res.body, 'Expected Response Body').toEqual(expectedRes)
     })
-})
+
+    it.e2eTest(
+        'should suggest a priority fee that is not the minimum',
+        ['solo', 'default-private'],
+        async () => {
+            const wallet = ThorWallet.withFunds()
+
+            const expectedMaxPriorityFee = 80
+            for (let i = 0; i < 8; i++) {
+                await sendTransactionsWithTip(wallet, expectedMaxPriorityFee, i)
+            }
+
+            const res = await Client.raw.getFeesPriority()
+
+            expect(res.success, 'API response should be a success').toBeTruthy()
+            expect(res.httpCode, 'Expected HTTP Code').toEqual(200)
+            const expectedRes = {
+                maxPriorityFeePerGas: HexUInt.of(expectedMaxPriorityFee).toString(),
+            }
+            expect(res.body, 'Expected Response Body').toEqual(expectedRes)
+        },
+    )
+}, timeout)

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -86,13 +86,13 @@ describe(
                 const wallet = ThorWallet.withFunds()
 
                 const expectedMaxPriorityFee = 80
-                
+
                 // Currently we check the priority fee for the last 20 blocks
-                
+
                 // This loop will create 8 transactions, 1 included in each block
-                
+
                 // Since we sort the fees and get the position related to the 60th percentile
-                
+
                 // We need to create at least 8 blocks to have a priority fee that is not the expected
                 // assuming that in other tests there are no higher fees than this one
                 for (let i = 0; i < 8; i++) {

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -86,6 +86,15 @@ describe(
                 const wallet = ThorWallet.withFunds()
 
                 const expectedMaxPriorityFee = 80
+                
+                // Currently we check the priority fee for the last 20 blocks
+                
+                // This loop will create 8 transactions, 1 included in each block
+                
+                // Since we sort the fees and get the position related to the 60th percentile
+                
+                // We need to create at least 8 blocks to have a priority fee that is not the expected
+                // assuming that in other tests there are no higher fees than this one
                 for (let i = 0; i < 8; i++) {
                     await sendTransactionsWithTip(
                         wallet,

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -80,7 +80,7 @@ describe(
         })
 
         it.e2eTest(
-            'should suggest a priority fee that is not the minimum',
+            'should suggest a priority fee that is above the current one',
             ['solo', 'default-private'],
             async () => {
                 const wallet = ThorWallet.withFunds()

--- a/test/thorest-api/fees/get-fees-priority.test.js
+++ b/test/thorest-api/fees/get-fees-priority.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'vitest'
+import { Client } from '../../../src/thor-client'
+import { HEX_AT_LEAST_1 } from '../../../src/utils/hex-utils'
+
+/**
+ * @group api
+ * @group fees
+ */
+describe('GET /fees/priority', function () {
+
+    it.e2eTest('get suggested priority fee', 'all', async () => {
+        const res = await Client.raw.getFeesPriority()
+
+        expect(res.success, 'API response should be a success').toBeTruthy()
+        expect(res.httpCode, 'Expected HTTP Code').toEqual(200)
+        const expectedRes = {
+            maxPriorityFeePerGas: expect.stringMatching(HEX_AT_LEAST_1),
+        }
+        expect(res.body, 'Expected Response Body').toEqual(expectedRes)
+    })
+})

--- a/test/thorest-api/transactions/fork/galactica/post-tx-negative.test.js
+++ b/test/thorest-api/transactions/fork/galactica/post-tx-negative.test.js
@@ -1,35 +1,12 @@
-import { DynFeeTransaction } from '../../../../../src/dyn-fee-transaction'
-import { Clause, Address, VET, Units, Hex } from '@vechain/sdk-core'
-import { ThorWallet } from '../../../../../src/wallet'
-import { getBlockRef } from '../../../../../src/utils/block-utils'
+import { Clause, Hex, Units, VET } from '@vechain/sdk-core'
 import { Client } from '../../../../../src/thor-client'
-import { generateNonce } from '../../../../../src/transactions'
+import { ThorWallet } from '../../../../../src/wallet'
 
 /**
  * @group api
  * @group transactions
  * @group fork
  */
-const buildTx = async (clauses, options) => {
-    const bestBlockRef = await getBlockRef('best')
-    const genesisBlock = await Client.raw.getBlock('0')
-
-    if (!genesisBlock.success || !genesisBlock.body?.id) {
-        throw new Error('Could not get best block')
-    }
-
-    return new DynFeeTransaction({
-        blockRef: bestBlockRef,
-        expiration: 1000,
-        clauses: clauses,
-        maxPriorityFeePerGas: options.maxPriorityFeePerGas ?? 10,
-        maxFeePerGas: options.maxFeePerGas ?? 10_000_000_000_000,
-        gas: 1_000_000,
-        dependsOn: options?.dependsOn ?? null,
-        nonce: generateNonce(),
-        chainTag: parseInt(genesisBlock.body.id.slice(-2), 16),
-    })
-}
 
 describe('POST /transactions', () => {
     it.e2eTest(
@@ -47,9 +24,8 @@ describe('POST /transactions', () => {
             expect(bestBlk.success).toBeTruthy()
 
             const baseFee = bestBlk.body?.baseFee
-            const tx = await wallet.signTransaction(
-                await buildTx([clause], { maxFeePerGas: baseFee - 1 }),
-            )
+            const txBody = await wallet.buildTransaction([clause], { isDynFeeTx: true, maxFeePerGas: baseFee - 1 })
+            const tx = await wallet.signTransaction(txBody)
 
             const hex = Hex.of(tx.encoded)
 

--- a/test/thorest-api/transactions/fork/galactica/post-tx-negative.test.js
+++ b/test/thorest-api/transactions/fork/galactica/post-tx-negative.test.js
@@ -58,12 +58,12 @@ describe('POST /transactions', () => {
             expect(bestBlk.success).toBeTruthy()
 
             const baseFee = bestBlk.body?.baseFee
-            const tx = await wallet.signTransaction(
-                await buildTx([clause], {
-                    maxPriorityFeePerGas: baseFee * 10,
-                    maxFeePerGas: baseFee,
-                }),
-            )
+            const txBody = await wallet.buildTransaction([clause], {
+                isDynFeeTx: true,
+                maxPriorityFeePerGas: baseFee * 10,
+                maxFeePerGas: baseFee,
+            })
+            const tx = await wallet.signTransaction(txBody)
 
             const hex = Hex.of(tx.encoded)
 

--- a/test/thorest-api/transactions/fork/galactica/post-tx-negative.test.js
+++ b/test/thorest-api/transactions/fork/galactica/post-tx-negative.test.js
@@ -24,7 +24,10 @@ describe('POST /transactions', () => {
             expect(bestBlk.success).toBeTruthy()
 
             const baseFee = bestBlk.body?.baseFee
-            const txBody = await wallet.buildTransaction([clause], { isDynFeeTx: true, maxFeePerGas: baseFee - 1 })
+            const txBody = await wallet.buildTransaction([clause], {
+                isDynFeeTx: true,
+                maxFeePerGas: baseFee - 1,
+            })
             const tx = await wallet.signTransaction(txBody)
 
             const hex = Hex.of(tx.encoded)

--- a/test/thorest-api/transactions/fork/galactica/post-tx-positive.test.js
+++ b/test/thorest-api/transactions/fork/galactica/post-tx-positive.test.js
@@ -1,8 +1,5 @@
 import { Clause, Hex, Units, VET } from '@vechain/sdk-core'
-import { DynFeeTransaction } from '../../../../../src/dyn-fee-transaction'
 import { Client } from '../../../../../src/thor-client'
-import { generateNonce } from '../../../../../src/transactions'
-import { getBlockRef } from '../../../../../src/utils/block-utils'
 import { ThorWallet } from '../../../../../src/wallet'
 import {
     checkTransactionLogSuccess,
@@ -35,7 +32,10 @@ describe('POST /transactions', () => {
             expect(bestBlk.success).toBeTruthy()
 
             const baseFee = bestBlk.body?.baseFee
-            const txBody = await wallet.buildTransaction([clause], { isDynFeeTx: true, maxFeePerGas: baseFee })
+            const txBody = await wallet.buildTransaction([clause], {
+                isDynFeeTx: true,
+                maxFeePerGas: baseFee,
+            })
             const signedTx = await wallet.signTransaction(txBody)
 
             const testPlan = {

--- a/test/thorest-api/transactions/fork/galactica/post-tx-positive.test.js
+++ b/test/thorest-api/transactions/fork/galactica/post-tx-positive.test.js
@@ -1,10 +1,9 @@
+import { Clause, Hex, Units, VET } from '@vechain/sdk-core'
 import { DynFeeTransaction } from '../../../../../src/dyn-fee-transaction'
-import { Clause, Address, VET, Units, Hex } from '@vechain/sdk-core'
-import { ThorWallet } from '../../../../../src/wallet'
-import { getBlockRef } from '../../../../../src/utils/block-utils'
 import { Client } from '../../../../../src/thor-client'
 import { generateNonce } from '../../../../../src/transactions'
-import { TransactionDataDrivenFlow } from '../../setup/transaction-data-driven-flow'
+import { getBlockRef } from '../../../../../src/utils/block-utils'
+import { ThorWallet } from '../../../../../src/wallet'
 import {
     checkTransactionLogSuccess,
     checkTxInclusionInBlock,
@@ -12,6 +11,7 @@ import {
     successfulPostTx,
     successfulReceipt,
 } from '../../setup/asserts'
+import { TransactionDataDrivenFlow } from '../../setup/transaction-data-driven-flow'
 
 /**
  * @group api

--- a/test/thorest-api/transactions/setup/asserts.js
+++ b/test/thorest-api/transactions/setup/asserts.js
@@ -135,5 +135,13 @@ const checkTransactionLogSuccess = (input, block, tx, transferClauses) => {
 }
 
 export {
-    checkDelegatedTransaction, checkDelegatedTransactionReceipt, checkTransactionLogSuccess, checkTxInclusionInBlock, compareSentTxWithCreatedTx, revertedPostTx, successfulPostTx, successfulReceipt, unsuccessfulReceipt
+    checkDelegatedTransaction,
+    checkDelegatedTransactionReceipt,
+    checkTransactionLogSuccess,
+    checkTxInclusionInBlock,
+    compareSentTxWithCreatedTx,
+    revertedPostTx,
+    successfulPostTx,
+    successfulReceipt,
+    unsuccessfulReceipt,
 }

--- a/test/thorest-api/transactions/setup/asserts.js
+++ b/test/thorest-api/transactions/setup/asserts.js
@@ -1,6 +1,5 @@
-import { ethers, hexlify } from 'ethers'
-import hexUtils from '../../../../src/utils/hex-utils'
 import { Hex } from '@vechain/sdk-core'
+import hexUtils from '../../../../src/utils/hex-utils'
 
 /**
  * Functions to be used in the test plan
@@ -136,13 +135,5 @@ const checkTransactionLogSuccess = (input, block, tx, transferClauses) => {
 }
 
 export {
-    successfulPostTx,
-    revertedPostTx,
-    compareSentTxWithCreatedTx,
-    checkDelegatedTransaction,
-    successfulReceipt,
-    checkDelegatedTransactionReceipt,
-    checkTxInclusionInBlock,
-    checkTransactionLogSuccess,
-    unsuccessfulReceipt,
+    checkDelegatedTransaction, checkDelegatedTransactionReceipt, checkTransactionLogSuccess, checkTxInclusionInBlock, compareSentTxWithCreatedTx, revertedPostTx, successfulPostTx, successfulReceipt, unsuccessfulReceipt
 }


### PR DESCRIPTION
e2e tests for `fees/priority`.

Some refactor so we can build dynamic fee transactions using the same method as the legacy ones.