### PR TITLE
Add postive and negative tests for dynamic fee market

### DIFF
--- a/src/transactions.js
+++ b/src/transactions.js
@@ -19,7 +19,7 @@ export const pollTransaction = async (
 ) => {
     return new Promise((resolve, reject) => {
         const intervalId = setInterval(async () => {
-            const tx = await Client.raw.getTransaction(txId, queryParams)
+            const tx = await client.getTransaction(txId, queryParams)
 
             if (tx.success && tx.body) {
                 clearInterval(intervalId) // Clear the interval when the receipt is found


### PR DESCRIPTION
|Test case|Result|
|----------|------|
|Send legacy and dyn fee txs with maxFeePerGas < baseFee | ⛔ |
| Sending legacy tx before and after the forks activates | Consumes the same amount of energy |
|Sending dyn fee tx after the fork, collect block, receipt and tx data | Check the coherence with what's been paid |